### PR TITLE
feat: make emoji feedback stickers configurable

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -524,6 +524,48 @@
       }
     }
   },
+  "emoji_feedback": {
+    "description": "贴表情反馈",
+    "hint": "在用户消息上贴表情标注任务状态（处理中/成功/失败）。仅支持 set_msg_emoji_like 的平台（如 aiocqhttp/QQ）生效，其余平台自动跳过。",
+    "type": "object",
+    "items": {
+      "enabled": {
+        "type": "bool",
+        "description": "启用贴表情反馈",
+        "hint": "关闭后不再在用户消息上贴任何表情。",
+        "default": true
+      },
+      "emoji_type": {
+        "type": "string",
+        "description": "表情类型",
+        "hint": "1=QQ 原生表情；2=Unicode emoji；326=QQ 黄豆表情。",
+        "options": [
+          "1",
+          "2",
+          "326"
+        ],
+        "default": "1"
+      },
+      "processing": {
+        "type": "int",
+        "description": "处理中表情 ID",
+        "hint": "默认 125=转圈。可改为其他表情 ID。",
+        "default": 125
+      },
+      "success": {
+        "type": "int",
+        "description": "成功表情 ID",
+        "hint": "默认 79=胜利。可改为其他表情 ID。",
+        "default": 79
+      },
+      "failed": {
+        "type": "int",
+        "description": "失败表情 ID",
+        "hint": "默认 106=委屈。可改为其他表情 ID。",
+        "default": 106
+      }
+    }
+  },
   "debounce_interval": {
     "description": "防抖时长(秒)",
     "hint": "防抖时间内无法重复提交生成/改图请求，每个用户单独计时",

--- a/core/emoji_feedback.py
+++ b/core/emoji_feedback.py
@@ -24,6 +24,58 @@ class EmojiID:
     FAILED = 106  # 😞 失败 (委屈)
 
 
+# 运行期配置（由 configure_emoji_feedback 注入）
+_CONFIG: dict[str, Any] = {
+    "enabled": True,
+    "emoji_type": "1",
+    "processing": EmojiID.PROCESSING,
+    "success": EmojiID.SUCCESS,
+    "failed": EmojiID.FAILED,
+}
+
+
+def configure_emoji_feedback(config: dict | None) -> None:
+    """从插件配置中读取贴表情反馈设置。
+
+    Args:
+        config: 插件配置的 emoji_feedback 段；传空则使用内置默认值。
+    """
+    _CONFIG.clear()
+    _CONFIG.update(
+        {
+            "enabled": True,
+            "emoji_type": "1",
+            "processing": EmojiID.PROCESSING,
+            "success": EmojiID.SUCCESS,
+            "failed": EmojiID.FAILED,
+        }
+    )
+    if not isinstance(config, dict):
+        return
+
+    enabled = config.get("enabled")
+    if enabled is not None:
+        _CONFIG["enabled"] = bool(enabled)
+
+    emoji_type = str(config.get("emoji_type") or "").strip()
+    if emoji_type:
+        _CONFIG["emoji_type"] = emoji_type
+
+    for key in ("processing", "success", "failed"):
+        raw = config.get(key)
+        if raw in (None, ""):
+            continue
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            logger.warning("[emoji_feedback] 忽略无效的 %s 表情 ID: %r", key, raw)
+            continue
+        if 0 <= value <= 65535:
+            _CONFIG[key] = value
+        else:
+            logger.warning("[emoji_feedback] 忽略越界的 %s 表情 ID: %r", key, raw)
+
+
 async def _get_message_id(event: AstrMessageEvent) -> int | None:
     """从事件中提取消息 ID"""
     try:
@@ -70,6 +122,10 @@ async def set_emoji(
     Returns:
         是否成功
     """
+    if not _CONFIG.get("enabled", True):
+        return False
+    emoji_type = str(_CONFIG.get("emoji_type") or emoji_type or "1")
+
     message_id = await _get_message_id(event)
     if message_id is None:
         logger.debug("[emoji_feedback] 无法获取消息ID，跳过贴表情")
@@ -103,14 +159,14 @@ async def set_emoji(
 
 async def mark_processing(event: AstrMessageEvent) -> bool:
     """标记消息为处理中状态"""
-    return await set_emoji(event, EmojiID.PROCESSING)
+    return await set_emoji(event, int(_CONFIG.get("processing", EmojiID.PROCESSING)))
 
 
 async def mark_success(event: AstrMessageEvent) -> bool:
     """标记消息为成功状态"""
-    return await set_emoji(event, EmojiID.SUCCESS)
+    return await set_emoji(event, int(_CONFIG.get("success", EmojiID.SUCCESS)))
 
 
 async def mark_failed(event: AstrMessageEvent) -> bool:
     """标记消息为失败状态"""
-    return await set_emoji(event, EmojiID.FAILED)
+    return await set_emoji(event, int(_CONFIG.get("failed", EmojiID.FAILED)))

--- a/main.py
+++ b/main.py
@@ -56,7 +56,12 @@ from .core.batch_executor import BatchRunResult, run_batch
 from .core.debouncer import Debouncer
 from .core.draw_service import ImageDrawService
 from .core.edit_router import EditRouter
-from .core.emoji_feedback import mark_failed, mark_processing, mark_success
+from .core.emoji_feedback import (
+    configure_emoji_feedback,
+    mark_failed,
+    mark_processing,
+    mark_success,
+)
 from .core.gitee_sizes import (
     GITEE_SUPPORTED_RATIOS,
     normalize_size_text,
@@ -636,6 +641,8 @@ class GiteeAIImagePlugin(Star):
             pass
 
     async def initialize(self):
+        configure_emoji_feedback(self.config.get("emoji_feedback", {}))
+
         self.debouncer = Debouncer(self.config)
         self.imgr = ImageManager(self.config, self.data_dir)
         self.registry = ProviderRegistry(

--- a/tests/test_batch_result_delivery.py
+++ b/tests/test_batch_result_delivery.py
@@ -375,6 +375,7 @@ def _load_module():
     _install_stub_module(f"{CORE_PACKAGE_NAME}.edit_router", EditRouter=_StubRouter)
     _install_stub_module(
         f"{CORE_PACKAGE_NAME}.emoji_feedback",
+        configure_emoji_feedback=lambda *args, **kwargs: None,
         mark_failed=lambda *args, **kwargs: None,
         mark_processing=lambda *args, **kwargs: None,
         mark_success=lambda *args, **kwargs: None,

--- a/tests/test_emoji_feedback.py
+++ b/tests/test_emoji_feedback.py
@@ -1,0 +1,114 @@
+import asyncio
+
+import pytest
+from core.emoji_feedback import (
+    _CONFIG,
+    EmojiID,
+    _get_message_id,
+    configure_emoji_feedback,
+    mark_failed,
+    mark_processing,
+    mark_success,
+    set_emoji,
+)
+
+
+class FakeBot:
+    def __init__(self):
+        self.calls = []
+
+    async def set_msg_emoji_like(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class FakeMessageObj:
+    def __init__(self, message_id):
+        self.raw_message = {"message_id": message_id}
+
+
+class FakeEvent:
+    def __init__(self, message_id=100, bot=None):
+        self.message_obj = FakeMessageObj(message_id)
+        self.bot = bot or FakeBot()
+
+
+def test_configure_defaults_reset_everything():
+    configure_emoji_feedback(None)
+    assert _CONFIG["enabled"] is True
+    assert _CONFIG["emoji_type"] == "1"
+    assert _CONFIG["processing"] == EmojiID.PROCESSING
+    assert _CONFIG["success"] == EmojiID.SUCCESS
+    assert _CONFIG["failed"] == EmojiID.FAILED
+
+
+def test_configure_applies_custom_emoji_ids():
+    configure_emoji_feedback(
+        {
+            "enabled": False,
+            "emoji_type": "326",
+            "processing": "10",
+            "success": 20,
+            "failed": "30",
+        }
+    )
+    assert _CONFIG["enabled"] is False
+    assert _CONFIG["emoji_type"] == "326"
+    assert _CONFIG["processing"] == 10
+    assert _CONFIG["success"] == 20
+    assert _CONFIG["failed"] == 30
+
+
+def test_configure_ignores_invalid_emoji_ids():
+    configure_emoji_feedback({"processing": "abc", "success": "-1", "failed": 999999})
+    assert _CONFIG["processing"] == EmojiID.PROCESSING
+    assert _CONFIG["success"] == EmojiID.SUCCESS
+    assert _CONFIG["failed"] == EmojiID.FAILED
+
+
+def test_get_message_id_extracts_raw_message():
+    configure_emoji_feedback(None)
+    assert asyncio.run(_get_message_id(FakeEvent(message_id=42))) == 42
+
+
+@pytest.mark.asyncio
+async def test_disabled_skips_all_stickers():
+    configure_emoji_feedback({"enabled": False})
+    bot = FakeBot()
+    event = FakeEvent(bot=bot)
+    assert await mark_processing(event) is False
+    assert await mark_success(event) is False
+    assert await mark_failed(event) is False
+    assert bot.calls == []
+
+
+@pytest.mark.asyncio
+async def test_mark_uses_configured_ids_and_type():
+    configure_emoji_feedback(
+        {
+            "enabled": True,
+            "emoji_type": "326",
+            "processing": 10,
+            "success": 20,
+            "failed": 30,
+        }
+    )
+    bot = FakeBot()
+    event = FakeEvent(bot=bot)
+    assert await mark_processing(event) is True
+    assert await mark_success(event) is True
+    assert await mark_failed(event) is True
+    ids = [call["emoji_id"] for call in bot.calls]
+    types = [call["emoji_type"] for call in bot.calls]
+    assert ids == [10, 20, 30]
+    assert types == ["326", "326", "326"]
+
+
+@pytest.mark.asyncio
+async def test_bot_without_api_is_skipped():
+    configure_emoji_feedback(None)
+
+    class NoApiBot:
+        pass
+
+    event = FakeEvent(bot=NoApiBot())
+    assert await set_emoji(event, EmojiID.SUCCESS) is False

--- a/tests/test_main_initialize_request_mode.py
+++ b/tests/test_main_initialize_request_mode.py
@@ -352,6 +352,7 @@ def _load_module():
     )
     _install_stub_module(
         f"{CORE_PACKAGE_NAME}.emoji_feedback",
+        configure_emoji_feedback=lambda *args, **kwargs: None,
         mark_failed=lambda *args, **kwargs: None,
         mark_processing=lambda *args, **kwargs: None,
         mark_success=lambda *args, **kwargs: None,


### PR DESCRIPTION
## 贴表情功能配置化

### 变更内容
为贴表情反馈功能新增配置项，支持总开关与按任务状态自定义表情。

- **配置**（`_conf_schema.json`）：新增 `emoji_feedback` 配置段
  - `enabled`：贴表情总开关（默认 `true`，关闭后不再贴任何表情）
  - `emoji_type`：表情类型（`1`=QQ 原生 / `2`=Unicode emoji / `326`=QQ 黄豆）
  - `processing` / `success` / `failed`：处理中 / 成功 / 失败三种情况各自的 QQ 表情 ID（默认 `125`/`79`/`106`，支持 0~65535，非法或越界值自动忽略并回退默认）
- **实现**（`core/emoji_feedback.py`）：新增 `configure_emoji_feedback()`，`mark_processing`/`mark_success`/`mark_failed` 改为读取配置；`set_emoji` 在开关关闭时直接跳过
- **接线**（`main.py`）：`initialize()` 时注入配置，保存配置后重载即生效
- **测试**：新增 `tests/test_emoji_feedback.py`（开关、自定义 ID、非法值容错、无 API bot 跳过等 7 例）；为既有 main.py 测试桩补上 `configure_emoji_feedback`

### 兼容性
默认值与原行为完全一致，未配置时表现不变。

### 验证
- `pytest`：130 passed
- `ruff check` / `ruff format --check`：通过
